### PR TITLE
feat: Display metric multiplier inline with label

### DIFF
--- a/releases/4_inline_metric_value_display.md
+++ b/releases/4_inline_metric_value_display.md
@@ -1,0 +1,74 @@
+# Action Plan for Issue #4: Change Metric Value Position
+
+## Issue Summary
+Move the metric multiplier value to display **inline with the label** in parentheses instead of on a separate line.
+
+**Current format:**
+```
+4★ within 10 min
+1.5×
+```
+
+**Target format:**
+```
+4★ within 10 min (1.5×)
+```
+
+## Action Plan
+
+### 1. Analyze Current UI Structure ✅
+- **Current Implementation**: `MetricTile.tsx` displays label and multiplier in separate `<div>` elements
+- **Current CSS**: `.metric-tile__label` and `.metric-tile__multiplier` are styled independently
+- **Impact**: Need to merge these into a single display line
+
+### 2. Update MetricTile Component
+- Modify `MetricTile.tsx` to combine label and multiplier in one `<div>`
+- Format as: `{label} ({value}×)`
+- Remove the separate `.metric-tile__multiplier` div
+- Preserve accessibility attributes
+
+### 3. Update CSS Styling
+- Update `MetricTile.css` to remove `.metric-tile__multiplier` styles
+- Add styling for inline multiplier display (e.g., lighter color, smaller font-weight for the parenthetical)
+- Ensure proper spacing and readability
+- Test on mobile/desktop layouts
+
+### 4. Test and Validate
+- Run `npm run lint` to check for errors
+- Run `npm run build` to ensure successful compilation
+- Manual testing:
+  - Verify all 4 metrics display correctly
+  - Check mobile responsiveness
+  - Ensure "Deal Breaker" badge still displays properly
+  - Test selected/unselected states
+
+### 5. Commit and Create PR
+- Create feature branch: `feature/inline-metric-value`
+- Commit with message: "feat: Display metric multiplier inline with label"
+- Push to GitHub
+- Create pull request referencing issue #4
+
+## Estimated Effort
+- **Time**: 30-45 minutes
+- **Complexity**: Low (UI-only change, no logic modification)
+- **Files to modify**: 2 files (`MetricTile.tsx`, `MetricTile.css`)
+
+## Technical Details
+
+**Before:**
+```tsx
+<div className="metric-tile__label">{option.label}</div>
+<div className="metric-tile__multiplier">{option.value.toFixed(2)}×</div>
+```
+
+**After:**
+```tsx
+<div className="metric-tile__label">
+  {option.label} <span className="metric-tile__multiplier">({option.value.toFixed(2)}×)</span>
+</div>
+```
+
+## Notes
+- This is a visual-only change; no logic modification required
+- Maintains existing accessibility features
+- Example output: "4★ within 10 min (1.5×)"

--- a/src/components/MetricTile.css
+++ b/src/components/MetricTile.css
@@ -8,10 +8,10 @@
   cursor: pointer;
   transition: all 0.2s ease;
   position: relative;
-  min-height: 120px;
+  min-height: 80px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
 }
 
 .metric-tile:hover {
@@ -42,12 +42,14 @@
   font-weight: 600;
   color: #1f2937;
   margin-bottom: 0.5rem;
+  line-height: 1.5;
 }
 
 .metric-tile__multiplier {
   font-size: 0.875rem;
   color: #6b7280;
-  font-weight: 500;
+  font-weight: 400;
+  margin-left: 0.25rem;
 }
 
 .metric-tile__badge {

--- a/src/components/MetricTile.tsx
+++ b/src/components/MetricTile.tsx
@@ -15,8 +15,9 @@ function MetricTile({ option, selected, onSelect }: MetricTileProps) {
       className={`metric-tile ${selected ? 'metric-tile--selected' : ''} ${option.gateFail ? 'metric-tile--gatefail' : ''}`}
       aria-pressed={selected}
     >
-      <div className="metric-tile__label">{option.label}</div>
-      <div className="metric-tile__multiplier">{option.value.toFixed(2)}×</div>
+      <div className="metric-tile__label">
+        {option.label} <span className="metric-tile__multiplier">({option.value.toFixed(2)}×)</span>
+      </div>
       {option.gateFail && <div className="metric-tile__badge">Deal Breaker</div>}
     </button>
   );


### PR DESCRIPTION
- Move multiplier value to display inline with label in parentheses
- Update MetricTile component to combine label and multiplier
- Adjust CSS styling for inline display with lighter weight
- Reduce tile min-height from 120px to 80px for better density
- Format: 'Label (value×)' instead of separate lines

Closes #4