### PR TITLE
feat: Position score panel on right with sticky behavior

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,426 @@
+# GitHub Copilot Instructions - Property Estimator App
+
+This document provides instructions for GitHub Copilot when assisting with development of this project. It outlines the workflow, file naming conventions, and quality standards that must be followed.
+
+---
+
+## Table of Contents
+
+1. [File Naming Conventions](#file-naming-conventions)
+2. [Development Workflow](#development-workflow)
+3. [Pre-PR Checklist](#pre-pr-checklist)
+4. [Branch Naming](#branch-naming)
+5. [Commit Message Format](#commit-message-format)
+6. [Testing Requirements](#testing-requirements)
+7. [Pull Request Process](#pull-request-process)
+
+---
+
+## File Naming Conventions
+
+### Release Documentation (`releases/*`)
+
+All feature implementations and changes must be documented in the `releases/` directory.
+
+**Naming Pattern:**
+```
+releases/{issue-number}_{short_description}.md
+```
+
+**Examples:**
+- `releases/1_change_layout_to_rows.md`
+- `releases/2_edit_json_on_the_home_page.md`
+- `releases/4_inline_metric_value_display.md`
+
+**Required Sections:**
+```markdown
+# Action Plan for Issue #{number}: {Title}
+
+## Issue Summary
+Brief description of the change
+
+## Action Plan
+1. Step 1
+2. Step 2
+...
+
+## Estimated Effort
+- Time: X hours
+- Complexity: Low/Medium/High
+- Files to modify: N files
+
+## Technical Details
+Code snippets, implementation notes
+
+## Notes
+Additional context
+```
+
+### Component Files
+- Use PascalCase for components: `MetricTile.tsx`
+- Matching CSS files: `MetricTile.css`
+- Utility/helper files: camelCase `computeScore.ts`
+
+### Type Definitions
+- Place in `src/types.ts` or colocate with components
+- Use TypeScript interfaces and types
+
+---
+
+## Development Workflow
+
+### 1. Create Issue Documentation
+
+Before starting work, create a release documentation file:
+
+```bash
+# Create the action plan file
+touch releases/{issue-number}_{description}.md
+
+# Edit the file with issue summary, action plan, technical details
+```
+
+### 2. Create Feature Branch
+
+```bash
+# Create and switch to feature branch
+git checkout -b feature/{descriptive-name}
+
+# Examples:
+git checkout -b feature/inline-metric-value
+git checkout -b feature/edit-json-config
+```
+
+### 3. Implement Changes
+
+Make your code changes following the action plan in your release documentation.
+
+### 4. Run Quality Checks
+
+**Before committing**, run all checks:
+
+```bash
+# 1. Run linter
+npm run lint
+
+# 2. Run TypeScript compiler and build
+npm run build
+
+# 3. Test locally (optional but recommended)
+npm run dev
+# Visit http://localhost:5173 and manually test changes
+```
+
+**All checks must pass with no errors before proceeding.**
+
+### 5. Commit Changes
+
+```bash
+# Stage all changes
+git add .
+
+# Commit with conventional commit message
+git commit -m "feat: {brief description}
+
+{detailed description}
+- Change 1
+- Change 2
+
+Closes #{issue-number}"
+```
+
+### 6. Push and Create PR
+
+```bash
+# Push to remote
+git push origin feature/{branch-name}
+
+# Create PR via GitHub UI or CLI
+# PR link will be shown in terminal output
+```
+
+---
+
+## Pre-PR Checklist
+
+Before creating a pull request, ensure:
+
+### ✅ Documentation
+- [ ] Release documentation file created in `releases/`
+- [ ] Action plan includes all required sections
+- [ ] Technical details and code snippets documented
+
+### ✅ Code Quality
+- [ ] `npm run lint` passes with no errors
+- [ ] `npm run build` completes successfully
+- [ ] No TypeScript compilation errors
+- [ ] Code follows existing patterns and conventions
+
+### ✅ Testing
+- [ ] Manual testing completed locally
+- [ ] All features work as expected
+- [ ] Responsive design verified (mobile + desktop)
+- [ ] Accessibility features maintained (keyboard nav, ARIA labels)
+- [ ] No console errors or warnings
+
+### ✅ Git Hygiene
+- [ ] Feature branch created from `main`
+- [ ] Descriptive branch name used
+- [ ] Commit messages follow conventional format
+- [ ] All changes staged and committed
+- [ ] Branch pushed to remote
+
+### ✅ Files Updated
+- [ ] Source files modified as needed
+- [ ] CSS updated if UI changes made
+- [ ] Types updated if data structures changed
+- [ ] Release documentation added to commit
+
+---
+
+## Branch Naming
+
+Use descriptive branch names following this pattern:
+
+### Feature Branches
+```
+feature/{short-description}
+```
+
+**Examples:**
+- `feature/inline-metric-value`
+- `feature/edit-json-config`
+- `feature/add-dark-mode`
+
+### Bugfix Branches
+```
+bugfix/{issue-or-description}
+```
+
+**Examples:**
+- `bugfix/score-calculation-error`
+- `bugfix/mobile-layout-issue`
+
+### Other Branch Types
+- `hotfix/{critical-issue}` - For urgent production fixes
+- `chore/{task}` - For maintenance tasks
+- `docs/{update}` - For documentation-only changes
+
+---
+
+## Commit Message Format
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+```
+<type>: <subject>
+
+<body>
+
+<footer>
+```
+
+### Types
+- `feat:` - New feature
+- `fix:` - Bug fix
+- `docs:` - Documentation only
+- `style:` - Code style changes (formatting, no logic change)
+- `refactor:` - Code refactoring
+- `test:` - Adding or updating tests
+- `chore:` - Maintenance tasks
+
+### Example
+```
+feat: Display metric multiplier inline with label
+
+- Move multiplier value to display inline with label in parentheses
+- Update MetricTile component to combine label and multiplier
+- Adjust CSS styling for inline display with lighter weight
+- Reduce tile min-height from 120px to 80px for better density
+
+Closes #4
+```
+
+---
+
+## Testing Requirements
+
+### Automated Tests
+```bash
+# Linting
+npm run lint
+
+# Build verification
+npm run build
+```
+
+### Manual Testing Checklist
+
+**For UI Changes:**
+- [ ] Test on desktop browser (Chrome/Firefox/Safari)
+- [ ] Test on mobile viewport (responsive design)
+- [ ] Test all interactive elements (clicks, hovers, focus states)
+- [ ] Verify accessibility (keyboard navigation, screen reader support)
+- [ ] Check for console errors
+
+**For Logic Changes:**
+- [ ] Test with various input combinations
+- [ ] Verify edge cases
+- [ ] Check error handling
+- [ ] Validate data persistence (localStorage)
+
+**For Config Changes:**
+- [ ] Test with default config
+- [ ] Test with modified config
+- [ ] Verify validation works
+- [ ] Check error messages display correctly
+
+---
+
+## Pull Request Process
+
+### 1. Create Pull Request
+
+Use the GitHub UI or URL provided after pushing:
+```
+https://github.com/saitejamalladi/property-estimator-app/pull/new/{branch-name}
+```
+
+### 2. PR Template
+
+**Title Format:**
+```
+{type}: {Brief description}
+```
+
+**Description Template:**
+```markdown
+## Description
+Brief overview of changes
+
+### Changes Made
+- Change 1
+- Change 2
+
+### Before/After
+Show visual changes if applicable
+
+### Features
+- ✅ Feature 1
+- ✅ Feature 2
+
+### Testing
+- ✅ Lint passed
+- ✅ Build successful
+- ✅ Manual testing completed
+
+### Files Changed
+- `path/to/file1` - Description
+- `path/to/file2` - Description
+
+Closes #{issue-number}
+```
+
+### 3. Review and Merge
+
+- Address any review comments
+- Ensure CI/CD checks pass (if configured)
+- Merge when approved
+- Delete feature branch after merge
+
+---
+
+## Local Development
+
+### Setup
+```bash
+# Install dependencies
+npm install
+
+# Start dev server
+npm run dev
+```
+
+### Available Scripts
+```bash
+npm run dev      # Start development server (http://localhost:5173)
+npm run build    # Build for production
+npm run lint     # Run ESLint
+npm run preview  # Preview production build locally
+```
+
+### Project Structure
+```
+property-estimator-app/
+├── src/
+│   ├── components/     # React components
+│   ├── assets/         # Static assets
+│   ├── types.ts        # TypeScript type definitions
+│   ├── config.ts       # Default configuration
+│   ├── computeScore.ts # Scoring logic
+│   ├── App.tsx         # Main app component
+│   └── main.tsx        # Entry point
+├── public/             # Public static files
+├── releases/           # Feature documentation
+├── docs/               # Project documentation
+├── package.json        # Dependencies and scripts
+├── vite.config.ts      # Vite configuration
+├── tsconfig.json       # TypeScript configuration
+└── eslint.config.js    # ESLint configuration
+```
+
+---
+
+## Deployment
+
+The app is automatically deployed to GitHub Pages via GitHub Actions.
+
+### Automatic Deployment
+- Pushes to `main` branch trigger automatic deployment
+- Check `.github/workflows/deploy.yml` for CI/CD configuration
+- View deployment status in the **Actions** tab
+
+### Manual Verification
+After merge to main:
+1. Wait for GitHub Actions to complete
+2. Visit: `https://saitejamalladi.github.io/property-estimator-app/`
+3. Verify changes are live
+
+---
+
+## Questions or Issues?
+
+- Check existing documentation in `docs/`
+- Review past issues and PRs for examples
+- Reference this instruction file for workflow guidance
+
+---
+
+## Summary: Required Workflow for Copilot
+
+```bash
+# 1. Create release doc
+touch releases/{N}_{description}.md
+
+# 2. Create feature branch
+git checkout -b feature/{name}
+
+# 3. Make changes
+
+# 4. Test (MANDATORY)
+npm run lint && npm run build
+
+# 5. Commit
+git add .
+git commit -m "feat: description"
+
+# 6. Push and create PR
+git push origin feature/{name}
+```
+
+**Critical:** Every change requires:
+1. Documentation in `releases/`
+2. Passing `npm run lint` with zero errors
+3. Successful `npm run build`
+4. Proper conventional commit message
+5. Reference to issue number in commit/PR

--- a/releases/6_score_panel_right_layout.md
+++ b/releases/6_score_panel_right_layout.md
@@ -1,0 +1,172 @@
+# Action Plan for Issue #6: Position of the Final Score
+
+## Issue Summary
+Change the layout to display metrics on the left side (60%) and the final score panel sticky on the right side (40%) in a side-by-side layout.
+
+**Current Layout:**
+```
+Header
+Property Title Input
+Metrics (full width)
+Score Panel (full width)
+Footer Actions
+```
+
+**Target Layout:**
+```
+Header
+Property Title Input
++-----------------------------------+-------------------+
+|                                   |                   |
+|  Metrics (60%)                    |  Score Panel (40%)|
+|  - Rows of metric tiles           |  - Sticky         |
+|                                   |  - Fixed position |
+|                                   |                   |
++-----------------------------------+-------------------+
+Footer Actions (full width)
+```
+
+## Action Plan
+
+### 1. Analyze Current Layout Structure ✅
+- **Current**: Vertical stack layout with full-width components
+- **App.tsx**: Components rendered sequentially without wrapper
+- **App.css**: Simple flex column layout
+- **Impact**: Need to create a main content wrapper with two-column layout
+
+### 2. Update App Component Structure
+- Wrap `MetricsGrid` and `ScorePanel` in a new container div (`.app__main`)
+- Keep `Header`, `PropertyTitleInput`, and `FooterActions` at full width
+- Maintain existing component logic (no prop changes needed)
+
+### 3. Update App.css for Two-Column Layout
+- Create `.app__main` wrapper with flexbox/grid layout
+- Set metrics area to 60% width
+- Set score panel to 40% width with sticky positioning
+- Add responsive breakpoint for mobile (stack vertically)
+- Ensure proper spacing and overflow handling
+
+### 4. Update ScorePanel.css (if needed)
+- Remove existing margins that might conflict with new layout
+- Ensure it works in sticky context
+- Adjust max-width constraints
+- Test overflow behavior
+
+### 5. Test and Validate
+- Run `npm run lint` to check for errors
+- Run `npm run build` to ensure successful compilation
+- Manual testing:
+  - Desktop: Verify side-by-side layout (60/40 split)
+  - Scroll behavior: Score panel stays sticky on right
+  - Mobile: Verify it stacks vertically (score below metrics)
+  - All screen sizes (tablet, desktop, wide desktop)
+  - Score panel remains visible when scrolling metrics
+
+### 6. Commit and Create PR
+- Create feature branch: `feature/score-panel-right-layout`
+- Commit with message: "feat: Position score panel on right side with sticky behavior"
+- Push to GitHub
+- Create pull request referencing issue #6
+
+## Estimated Effort
+- **Time**: 1-2 hours
+- **Complexity**: Medium (layout restructuring, responsive design)
+- **Files to modify**: 3 files (`App.tsx`, `App.css`, `ScorePanel.css`)
+
+## Technical Details
+
+### App.tsx Changes
+
+**Before:**
+```tsx
+return (
+  <div className="app">
+    <Header onEditSettings={handleEditSettings} />
+    <PropertyTitleInput value={propertyTitle} onChange={setPropertyTitle} />
+    <MetricsGrid config={config} selections={selections} onSelect={handleSelect} />
+    <ScorePanel propertyTitle={propertyTitle} scoreResult={scoreResult} />
+    <FooterActions onReset={handleReset} onCopy={handleCopy} />
+    <ConfigEditorModal ... />
+  </div>
+);
+```
+
+**After:**
+```tsx
+return (
+  <div className="app">
+    <Header onEditSettings={handleEditSettings} />
+    <PropertyTitleInput value={propertyTitle} onChange={setPropertyTitle} />
+    <div className="app__main">
+      <MetricsGrid config={config} selections={selections} onSelect={handleSelect} />
+      <ScorePanel propertyTitle={propertyTitle} scoreResult={scoreResult} />
+    </div>
+    <FooterActions onReset={handleReset} onCopy={handleCopy} />
+    <ConfigEditorModal ... />
+  </div>
+);
+```
+
+### App.css Changes
+
+**Add:**
+```css
+.app__main {
+  display: flex;
+  flex: 1;
+  gap: 2rem;
+  padding: 2rem;
+  align-items: flex-start;
+}
+
+.app__main > *:first-child {
+  flex: 0 0 60%;
+  min-width: 0; /* Prevent flex overflow */
+}
+
+.app__main > *:last-child {
+  flex: 0 0 40%;
+  position: sticky;
+  top: 2rem;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+}
+
+@media (max-width: 1024px) {
+  .app__main {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .app__main > *:first-child,
+  .app__main > *:last-child {
+    flex: 1 1 auto;
+    position: static;
+    max-height: none;
+  }
+}
+```
+
+### ScorePanel.css Changes
+
+**Update:**
+```css
+.score-panel {
+  /* Remove fixed margins that conflict with sticky layout */
+  margin: 0; /* was: margin: 2rem; */
+  /* Keep other styles */
+}
+```
+
+## Notes
+- Sticky positioning ensures score panel stays visible while scrolling through metrics
+- 60/40 split provides good balance between content and summary
+- Mobile breakpoint stacks components vertically for better UX
+- MetricsGrid padding should be adjusted to remove conflicts
+- ScorePanel already has internal padding, so container gap handles spacing
+
+## Considerations
+- Ensure score panel doesn't have max-width that's too restrictive for 40% viewport
+- Test with long metric lists to ensure sticky behavior works smoothly
+- Verify footer actions stay at bottom after layout change
+- Check z-index doesn't conflict with modal or other overlays

--- a/src/App.css
+++ b/src/App.css
@@ -19,11 +19,35 @@
 .app__main {
   display: flex;
   flex: 1;
-  flex-wrap: wrap;
+  gap: 2rem;
+  padding: 2rem;
+  align-items: flex-start;
+}
+
+.app__main > *:first-child {
+  flex: 0 0 60%;
+  min-width: 0;
+}
+
+.app__main > *:last-child {
+  flex: 0 0 40%;
+  position: sticky;
+  top: 2rem;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
 }
 
 @media (max-width: 1024px) {
   .app__main {
     flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  .app__main > *:first-child,
+  .app__main > *:last-child {
+    flex: 1 1 auto;
+    position: static;
+    max-height: none;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,15 +99,17 @@ ${scoreResult.failures.length > 0 ? `\nDeal Breakers:\n${scoreResult.failures.ma
         value={propertyTitle}
         onChange={setPropertyTitle}
       />
-      <MetricsGrid
-        config={config}
-        selections={selections}
-        onSelect={handleSelect}
-      />
-      <ScorePanel
-        propertyTitle={propertyTitle}
-        scoreResult={scoreResult}
-      />
+      <div className="app__main">
+        <MetricsGrid
+          config={config}
+          selections={selections}
+          onSelect={handleSelect}
+        />
+        <ScorePanel
+          propertyTitle={propertyTitle}
+          scoreResult={scoreResult}
+        />
+      </div>
       <FooterActions
         onReset={handleReset}
         onCopy={handleCopy}

--- a/src/components/MetricsGrid.css
+++ b/src/components/MetricsGrid.css
@@ -2,11 +2,11 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 2rem;
+  padding: 0;
 }
 
 @media (max-width: 768px) {
   .metrics-grid {
-    padding: 1rem;
+    padding: 0;
   }
 }

--- a/src/components/ScorePanel.css
+++ b/src/components/ScorePanel.css
@@ -3,9 +3,9 @@
   color: white;
   padding: 2rem;
   border-radius: 8px;
-  margin: 2rem;
+  margin: 0;
   min-width: 300px;
-  max-width: 400px;
+  width: 100%;
 }
 
 .score-panel__header {


### PR DESCRIPTION
- Wrap MetricsGrid and ScorePanel in .app__main container
- Implement 60/40 split layout (metrics left, score right)
- Add sticky positioning to score panel (stays visible on scroll)
- Update ScorePanel to remove margins and use full width in container
- Remove MetricsGrid padding (handled by parent container)
- Add responsive breakpoint: stacks vertically on mobile (<1024px)
- Improve spacing with gap and padding in main container

Closes #6