### PR TITLE
feat: add missing gateFail conditions to categories

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -310,7 +310,8 @@ export const DEFAULT_CONFIG: Config = {
         {
           "id": "over_1h",
           "label": "More than 1 hour",
-          "value": 0.75
+          "value": 0.75,
+          "gateFail": true
         }
       ]
     },
@@ -332,7 +333,8 @@ export const DEFAULT_CONFIG: Config = {
         {
           "id": "over_30m",
           "label": "More than 30 mins",
-          "value": 0.75
+          "value": 0.75,
+          "gateFail": true
         }
       ]
     },


### PR DESCRIPTION
- Added gateFail: true to 'More than 1 hour' option in Hindu Temples (value: 0.75)
- Added gateFail: true to 'More than 30 mins' option in Private Schools (value: 0.75)
- All 15 metrics now have at least one gateFail condition
- Ensures consistent deal-breaker logic across all property metrics